### PR TITLE
Ignore invalid BOMs according to RFC7159 section 8.1

### DIFF
--- a/lib/git-json-merge.js
+++ b/lib/git-json-merge.js
@@ -5,9 +5,9 @@ var detectIndent = require('detect-indent');
 var encoding = 'utf-8';
 
 function mergeJsonFiles (oursFileName, baseFileName, theirsFileName) {
-	var oursJson = fs.readFileSync(oursFileName, encoding);
-	var baseJson = fs.readFileSync(baseFileName, encoding);
-	var theirsJson = fs.readFileSync(theirsFileName, encoding);
+	var oursJson = stripBom(fs.readFileSync(oursFileName, encoding));
+	var baseJson = stripBom(fs.readFileSync(baseFileName, encoding));
+	var theirsJson = stripBom(fs.readFileSync(theirsFileName, encoding));
 	var newOursJson = mergeJson(oursJson, baseJson, theirsJson);
 	fs.writeFileSync(oursFileName, newOursJson, encoding);
 }
@@ -40,9 +40,14 @@ function selectIndent (oursIndent, baseIndent, theirsIndent) {
 	return oursIndent !== baseIndent ? oursIndent : theirsIndent !== baseIndent ? theirsIndent : baseIndent;
 }
 
+function stripBom (str) {
+	return str[0] === '\uFEFF' ? str.slice(1) : str;
+}
+
 module.exports = {
 	mergeJsonFiles: mergeJsonFiles,
 	mergeJson: mergeJson,
 	merge: merge,
-	selectIndent: selectIndent
+	selectIndent: selectIndent,
+	stripBom: stripBom
 }

--- a/test/git-json-merge.spec.js
+++ b/test/git-json-merge.spec.js
@@ -24,6 +24,14 @@ describe('gitJsonMerge', function () {
 		describeSelectIndentTest(2, 2, 4, 4);
 		describeSelectIndentTest(2, 4, 4, 2);
 	});
+
+	describe('stripBom', function () {
+		describeStripBomTest('[{"id":1,"field":"Foo"}]', '[{"id":1,"field":"Foo"}]');
+		describeStripBomTest('\uFEFF[{"id":1,"field":"Foo"}]', '[{"id":1,"field":"Foo"}]');
+		describeStripBomTest('[{"id":1,"field":"Foo"}]\uFEFF', '[{"id":1,"field":"Foo"}]\uFEFF');
+		describeStripBomTest('[{"id":1,\uFEFF"field":"Foo"}]', '[{"id":1,\uFEFF"field":"Foo"}]');
+		describeStripBomTest('\uFEFF[{"id":1,"field":"Foo"}]\uFEFF', '[{"id":1,"field":"Foo"}]\uFEFF');
+	});
 });
 
 function toString (object) {
@@ -63,6 +71,16 @@ function describeSelectIndentTest (ours, base, theirs, expected) {
 	describe('given arguments of ' + ours.length + ' as ours, ' + base.length + ' as base and '  + theirs.length + ' as theirs', function () {
 		var actual = gitJsonMerge.selectIndent(ours, base, theirs);
 		it('should return ' + expected.length, function () {
+			expect(actual).to.equal(expected);
+		})
+	});
+}
+
+function describeStripBomTest (str, expected)  {
+	describe('given arguments of ' + str.replace('\uFEFF', '<BOM>') + ' as str', function () {
+		var actual = gitJsonMerge.stripBom(str);
+
+		it('should return ' + expected.replace('\uFEFF', '<BOM>'), function () {
 			expect(actual).to.equal(expected);
 		})
 	});


### PR DESCRIPTION
According to RFC7159, JSON files must not cotain byte order marks (BOMs). But in the wild, they occassionally do. RFC7159 also explicitely states, that implementations MAY ignore existing BOMs.

I implemented exactly that, so existing BOMs will be stripped after reading the files in a efficient way. This makes this tool operable in a greater number of use-cases. Note that the merged file will not contain BOMs in any case, as required by RFC7159.